### PR TITLE
feat(enfocado): enfocado on-demand plugins are listed

### DIFF
--- a/configs/lua/theme.lua
+++ b/configs/lua/theme.lua
@@ -18,6 +18,22 @@ vim.cmd
 vim.g.tokyonight_style = "night" -- styles: storm, night and day.
 vim.g.onedark_style = "deep"     -- styles: dark, darker, cool, deep, warm and warmer.
 vim.g.enfocado_style = "nature"    -- styles: nature and neon.
+vim.g.enfocado_plugins = {
+  "cmp",
+  "dashboard",
+  "gitsigns",
+  "lsp",
+  "lsp-installer",
+  "matchup",
+  "packer",
+  "scrollview",
+  "telescope",
+  "todo-comments",
+  "tree",
+  "treesitter",
+  "vista",
+  "which-key",
+}
 vim.cmd("colorscheme onedark")
 
 function _G.make_codeart_transparent()


### PR DESCRIPTION
Added `vim.g.enfocado_plugins` variable that allows the theme to apply only to plugins that **CodeArt** supports by default. Which allows to considerably improve the performance of **Enfocado**.