### PR TITLE
No more partial upgrades on Arch

### DIFF
--- a/installer/linux-mac.sh
+++ b/installer/linux-mac.sh
@@ -34,7 +34,7 @@ pack_manager_install() {
     echo $2 "is not installed."
     echo "Installing" $2
     if [[ "$1" == "pacman" ]]; then
-      sudo pacman -Sy $3 --noconfirm
+      sudo pacman -Syu $3 --noconfirm
     elif [[ "$1" =~ "apt-get" ]]; then
       sudo apt update
       sudo apt install $4 -y


### PR DESCRIPTION
It was using the -Sy flag which is unsupported. It partially upgraded my system. To avoid this I put the -Syu flag which does a full system upgrade.