### PR TITLE
Replace buf_get_clients in lualine plugin

### DIFF
--- a/lua/plugins/lualine/components.lua
+++ b/lua/plugins/lualine/components.lua
@@ -40,7 +40,7 @@ end
 
 function M.lsp_name(msg)
   msg = msg or "Inactive"
-  local buf_clients = vim.lsp.buf_get_clients()
+  local buf_clients = vim.lsp.get_clients({bufnr = 0})
   if next(buf_clients) == nil then
     if type(msg) == "boolean" or #msg == 0 then
       return "Inactive"


### PR DESCRIPTION
⚠️ WARNING vim.lsp.buf_get_clients() is deprecated. Feature will be removed in Nvim 0.12
ADVICE:
- use vim.lsp.get_clients() instead.

:checkhealth seems to be happy with it, no more vim deprecation warning with this fix

